### PR TITLE
Support hyphen/standardize uppercase behaviour

### DIFF
--- a/_element.js
+++ b/_element.js
@@ -1,6 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 
-class <%= shortName %> extends LitElement {
+class <%= shortNameCaps %> extends LitElement {
 
 	static get properties() {
 		return {
@@ -31,4 +31,4 @@ class <%= shortName %> extends LitElement {
 		`;
 	}
 }
-customElements.define('<%= name %>', <%= shortName %>);
+customElements.define('<%= name %>', <%= shortNameCaps %>);

--- a/setup/configure-helper.js
+++ b/setup/configure-helper.js
@@ -30,7 +30,7 @@ class Helper {
 
 	setDerivedProperties() {
 		this.shortName = this.shortName.toLowerCase();
-		this.shortNameCaps = this.shortName.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+		this.shortNameCaps = this.shortName.replace(/-([a-z])/g, (g) => { return g[1].toUpperCase(); });
 		this.shortNameCaps = this.shortNameCaps.charAt(0).toUpperCase() + this.shortNameCaps.slice(1);
 		this.githubOrg = this.type === 'official' ? 'BrightspaceUI' : 'BrightspaceUILabs';
 		this.orgName = this.type === 'official' ? '@brightspace-ui' : '@brightspace-ui-labs';

--- a/setup/configure-helper.js
+++ b/setup/configure-helper.js
@@ -29,6 +29,9 @@ class Helper {
 	}
 
 	setDerivedProperties() {
+		this.shortName = this.shortName.toLowerCase();
+		this.shortNameCaps = this.shortName.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+		this.shortNameCaps = this.shortNameCaps.charAt(0).toUpperCase() + this.shortNameCaps.slice(1);
 		this.githubOrg = this.type === 'official' ? 'BrightspaceUI' : 'BrightspaceUILabs';
 		this.orgName = this.type === 'official' ? '@brightspace-ui' : '@brightspace-ui-labs';
 		this.packageName = `${this.orgName}/${this.shortName}`; // @brightspace-ui/element or @brightspace-ui-labs/element
@@ -86,6 +89,7 @@ class Helper {
 
 		const result = data.replace(/<%= name %>/g, this.name)
 			.replace(/<%= shortName %>/g, this.shortName)
+			.replace(/<%= shortNameCaps %>/g, this.shortNameCaps)
 			.replace(/<%= packageName %>/g, this.packageName)
 			.replace(/<%= description %>/g, this.description)
 			.replace(/<%= codeowner %>/g, this.codeowner)


### PR DESCRIPTION
e.g., if user enters "my-element" or "MyNeWeLeMeNt" when using the config script it can handle that in a more standardized way.